### PR TITLE
Add JSON capability to hamalertdiscord script

### DIFF
--- a/hamalert.py
+++ b/hamalert.py
@@ -33,7 +33,7 @@ def telnet_listener(host, port, username, password):
             while True:
                 data = tn.read_until(b"\n", timeout=30).decode("utf-8").strip()
                 if data != "":
-                    logging.info("Received data:", data)
+                    logging.info(f"Received data: {data}")
 
                 if data == f"Hello {username}, this is HamAlert":
                     continue

--- a/hamalert.py
+++ b/hamalert.py
@@ -1,6 +1,8 @@
+import argparse
 import telnetlib
 import json
 import requests
+import logging
 
 # Replace with your HamAlert username and password
 HAMALERT_USERNAME = "USERNAME"
@@ -14,9 +16,9 @@ def send_discord_webhook(content):
     headers = {"Content-Type": "application/json"}
     response = requests.post(DISCORD_WEBHOOK_URL, json=data, headers=headers)
     if response.status_code == 204:
-        print("Discord webhook sent successfully.")
+        logging.info("Discord webhook sent successfully.")
     else:
-        print("Failed to send Discord webhook. Status code:", response.status_code)
+        logging.error("Failed to send Discord webhook. Status code:", response.status_code)
 
 def telnet_listener(host, port, username, password):
     try:
@@ -28,7 +30,7 @@ def telnet_listener(host, port, username, password):
 
             while True:
                 data = tn.read_until(b"\n").decode("utf-8").strip()
-                print("Received data:", data)
+                logging.info("Received data:", data)
 
                 # Split the received data into separate pieces
                 pieces = data.split()
@@ -46,20 +48,32 @@ def telnet_listener(host, port, username, password):
 
                     send_discord_webhook(message)
                 else:
-                    print("Received data is not in the expected format. Skipping.")
-                    print("Number of pieces:", len(pieces))
-                    print("Received data:", pieces)
+                    logging.warning("Received data is not in the expected format. Skipping.")
+                    logging.warning("Number of pieces:", len(pieces))
+                    logging.info("Received data:", pieces)
 
     except ConnectionRefusedError:
-        print("Telnet connection refused. Make sure the server is running and reachable.")
+        logging.error("Telnet connection refused. Make sure the server is running and reachable.")
     except Exception as e:
-        print("An error occurred:", e)
+        logging.error("An error occurred:", e)
 
+def setup_args():
+    # Create an argument parser
+    parser = argparse.ArgumentParser()
 
+    # Add an argument for the logging level
+    parser.add_argument('-l', '--log-level', help='The logging level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'])
+
+    # Parse the arguments
+    args = parser.parse_args()
+
+    # Set the logging level
+    logging.basicConfig(level=args.log_level)
 
 if __name__ == "__main__":
     # HAM ALERT TELNET INFORMATION
     HOST = "hamalert.org"
     PORT = 7300
 
+    setup_args()
     telnet_listener(HOST, PORT, HAMALERT_USERNAME, HAMALERT_PASSWORD)

--- a/hamalert.py
+++ b/hamalert.py
@@ -1,5 +1,6 @@
 import argparse
 import telnetlib
+import time
 import json
 import requests
 import logging
@@ -27,30 +28,60 @@ def telnet_listener(host, port, username, password):
             tn.write(username.encode("utf-8") + b"\n")
             tn.read_until(b"password: ")
             tn.write(password.encode("utf-8") + b"\n")
+            initialized = False
 
             while True:
-                data = tn.read_until(b"\n").decode("utf-8").strip()
-                logging.info("Received data:", data)
+                data = tn.read_until(b"\n", timeout=30).decode("utf-8").strip()
+                if data != "":
+                    logging.info("Received data:", data)
 
-                # Split the received data into separate pieces
-                pieces = data.split()
+                if data == f"Hello {username}, this is HamAlert":
+                    continue
+                if data == f"{username} de HamAlert >":
+                    logging.info("Telnet connected, attempting to set JSON mode.")
+                    time.sleep(1)
+                    tn.write(b"set/json\n")
+                    continue
+                if data == "Operation successful":
+                    logging.info("Successfully set JSON mode")
+                    initialized = True
+                    continue
+                if not initialized:
+                    # Dont try to parse incoming data until finished setting up JSON mode.
+                    # It's possible a spot comes in right when we first connect which can't be parsed.
+                    continue
 
-                # Ensure that the data has enough pieces to extract relevant information
-                if len(pieces) >= 5 and pieces[1] == "de":
-                    source_call = pieces[2].strip(':')
-                    destination_call = pieces[3]
-                    frequency = pieces[4]
-                    timestamp = pieces[-1]
+                if data == "":
+                    # We must have hit the timeout case in the read.
+                    # Just send a keepalive command and try another read.
+                    logging.debug(f"10s timeout hit, sending no-op")
+                    tn.sock.sendall(telnetlib.IAC + telnetlib.NOP)
+                    continue
 
-                    # Construct the message for Discord webhook
-                    message = f"DX de {source_call} @ {timestamp}\n"
-                    message += f"{frequency} on {destination_call}"
+                # Split the received data into json object
+                try:
+                    data_dict = json.loads(data)
 
-                    send_discord_webhook(message)
-                else:
-                    logging.warning("Received data is not in the expected format. Skipping.")
-                    logging.warning("Number of pieces:", len(pieces))
-                    logging.info("Received data:", pieces)
+                    required_fields = {'fullCallsign', 'callsign', 'frequency', 'mode', 'spotter', 'time', 'source'}
+                    # Ensure that the data has enough pieces to extract relevant information
+                    if all(key in data_dict for key in required_fields):
+                        # Construct the message for Discord webhook
+                        message = f"SPOT: {data_dict['callsign']} seen by {data_dict['spotter']} on {data_dict['frequency']} MHz ({data_dict['mode']}) at {data_dict['time']} UTC"
+                        sota_fields = {'summitName', 'summitRef', 'summitPoints', 'summitHeight'}
+                        if all(key in data_dict for key in sota_fields):
+                            message = "SOTA " + message
+                            message += f"\nSummit: {data_dict['summitName']} -- {data_dict['summitRef']} -- a {data_dict['summitPoints']} point summit at {data_dict['summitHeight']}m elevation!"
+
+                    else:
+                        logging.warning("Received data is not in the expected format. Skipping.")
+                        logging.warning(f"Parsed data: {data_dict}")
+
+                except json.JSONDecodeError as e:
+                    resetJson = True
+                    message = data
+
+                logging.info(f"sending message to discord: {message}")
+                send_discord_webhook(message)
 
     except ConnectionRefusedError:
         logging.error("Telnet connection refused. Make sure the server is running and reachable.")


### PR DESCRIPTION
Did a few things:
1) added logging levels to make it easier to run as a system service with just warn+ logging, while debugging locally with --log=DEBUG or INFO
2) added a keepalive to the connection, so that the read times out after 30s, it sends a no-op keepalive command to the telnet session, and then tries another 30s read. I kept seeing issues with silent failures otherwise, not sure if this is the cleanest solution.
3) set JSON mode, and change over to JSON parsing. There's a lot more data in this, so I also rewrote the message format to take advantage of it for SOTA spots.

TODO: 
1) POTA info
2) explicit debug mode that doesn't post spots for testing
3) username/pw as command line arguments? Or just a separate py file? Feel like it would be nice to separate the config from the code.
4) if we're feeling crazy, testing? :p